### PR TITLE
Log correct test runner results file path

### DIFF
--- a/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/Program.cs
+++ b/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/Program.cs
@@ -88,7 +88,7 @@ namespace AventStack.ExtentReports.CLI
 
         private void ProcessSingle(string testResultsFilePath, string output, bool merge = false)
         {
-            _logger.WriteLine(LoggingLevel.Normal, $"Parsing test runner result file '{TestRunnerResultsFile}' ...");
+            _logger.WriteLine(LoggingLevel.Normal, $"Parsing test runner result file '{testResultsFilePath}' ...");
 
             // if a single report is required for each test results file (ie, no merges): 
             // must instantiate every time to clear pre-existing data


### PR DESCRIPTION
Since the --merge option was added, this was logging a blank file when -o option was used.