### PR TITLE
HtmlEncode the statusmessage before logged

### DIFF
--- a/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI.csproj
+++ b/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>

--- a/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/Parser/NUnitParser.cs
+++ b/ExtentReportsDotNetCLI/ExtentReportsDotNetCLI/Parser/NUnitParser.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using System.Web;
 
 namespace AventStack.ExtentReports.CLI.Parser
 {
@@ -108,7 +109,8 @@ namespace AventStack.ExtentReports.CLI.Parser
             statusMessage += tc.Element("output") != null ? tc.Element("output").Value.Trim() : string.Empty;
             statusMessage = (status == Status.Fail || status == Status.Error) ? MarkupHelper.CreateCodeBlock(statusMessage).GetMarkup() : statusMessage;
             statusMessage = string.IsNullOrEmpty(statusMessage) ? status.ToString() : statusMessage;
-            test.Log(status, statusMessage);
+            var statusMessageHtmlEncode = HttpUtility.HtmlEncode(statusMessage);
+            test.Log(status, statusMessageHtmlEncode);
         }
 
         private static void AssignTags(XElement tc, ExtentTest test)


### PR DESCRIPTION
If statusmessage contains special charcater, generated html report can't shows correctly.
So HtmlEncode the statusmessage before logged